### PR TITLE
Updated package install with json filter

### DIFF
--- a/logrotate/install.sls
+++ b/logrotate/install.sls
@@ -6,4 +6,4 @@
 {% set pkgs = [logrotate.pkg] if logrotate.pkg is string else logrotate.pkg %}
 logrotate-pkg:
   pkg.installed:
-    - pkgs: {{ pkgs }}
+    - pkgs: {{ pkgs | json }}


### PR DESCRIPTION
This issue is causing logrotate install to fail. https://github.com/saltstack/salt/issues/51925
I've added | json to mitigate.